### PR TITLE
Fix port configuration in Docker docs and format to ease copy/paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In other words, if you're planning to access the VM under `localhost:8888`, it w
 The following build templates are included:
 
 - `oe-virtualbox.json` -- A VirtualBox image
-- `oe-vagrant.json` -- A VirtualBox image packaged as a Vagrant box 
+- `oe-vagrant.json` -- A VirtualBox image packaged as a Vagrant box
 - `oe-vmware.json` -- A VMWare image
 - `oe-parallels.json` -- A Parallels image
 - `oe-docker.json` -- A Docker container
@@ -93,7 +93,8 @@ Then, to run a container, use the `docker run` command. You'll want to follow so
 
 `docker run -d -p <host_port>:<container_port> gibs/onearth:1.0.0 apachectl -D FOREGROUND`
 
-So to run a Docker container that's accessible via port 8080 on the host machine, run 
-`docker run -d -p 80:8080 gibs/onearth:1.0.0 apachectl -D FOREGROUND`.
+So to run a Docker container that's accessible via port 8080 on the host machine, run:
+
+`docker run -d -p 8080:8080 gibs/onearth:1.0.0 apachectl -D FOREGROUND`
 
 You can then view the OnEarth demo page by pointing your browser to: **[http://localhost:8080/onearth/demo](http://localhost:8080/onearth/demo)**.


### PR DESCRIPTION
The port configuration in the existing README connects port 8080 on the container to 80 on the host but says that it connects to 8080 on the host. Connecting to 80 on the host is problematic because it usually requires sudo causes port conflicts, especially on OSX.

I updated the example to connect from 8080 on the container to 8080 on the host and verified that it works.

I also updated the formatting slightly, because on my first try I accidentally copy/pasted the period at the end of the sentence as part of the command.
