### PR TITLE
Fix broken path to the onearth 1.3.1 tar file

### DIFF
--- a/bootstrap-docker.sh
+++ b/bootstrap-docker.sh
@@ -12,8 +12,8 @@ cd /home/onearth
 yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-centos96-9.6-3.noarch.rpm
 
 # Download, install onearth stuff
-wget https://github.com/nasa-gibs/onearth/releases/download/v1.3.1/onearth-1.3.1.el6.tar.gz
-tar xfvz onearth-1.3.1.el6.tar.gz
+wget https://github.com/nasa-gibs/onearth/releases/download/v1.3.1/onearth-1.3.1-9.el6.tar.gz
+tar xfvz onearth-1.3.1-9.el6.tar.gz
 yum install -y gibs-gdal*.rpm
 yum install -y onearth*.rpm
 

--- a/bootstrap-vagrant.sh
+++ b/bootstrap-vagrant.sh
@@ -11,8 +11,8 @@ cd /home/vagrant
 yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-centos96-9.6-3.noarch.rpm
 
 # Download, install onearth stuff
-wget https://github.com/nasa-gibs/onearth/releases/download/v1.3.1/onearth-1.3.1.el6.tar.gz
-tar xfvz onearth-1.3.1.el6.tar.gz
+wget https://github.com/nasa-gibs/onearth/releases/download/v1.3.1/onearth-1.3.1-9.el6.tar.gz
+tar xfvz onearth-1.3.1-9.el6.tar.gz
 yum install -y gibs-gdal*.rpm
 yum install -y onearth*.rpm
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,8 +12,8 @@ cd /home/onearth
 yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-centos96-9.6-3.noarch.rpm
 
 # Download, install onearth stuff
-wget https://github.com/nasa-gibs/onearth/releases/download/v1.3.1/onearth-1.3.1.el6.tar.gz
-tar xfvz onearth-1.3.1.el6.tar.gz
+wget https://github.com/nasa-gibs/onearth/releases/download/v1.3.1/onearth-1.3.1-9.el6.tar.gz
+tar xfvz onearth-1.3.1-9.el6.tar.gz
 yum install -y gibs-gdal*.rpm
 yum install -y onearth*.rpm
 


### PR DESCRIPTION
The build fails since the path to the onearth release tar files have changed.
See: https://github.com/nasa-gibs/onearth/releases